### PR TITLE
Add sample API endpoint for getting todos, and add sample test

### DIFF
--- a/content/post/aspiretunit/AspireSample/AspireSample.ApiService/Program.cs
+++ b/content/post/aspiretunit/AspireSample/AspireSample.ApiService/Program.cs
@@ -33,6 +33,12 @@ app.MapGet("/weatherforecast", () =>
     return forecast;
 });
 
+app.MapGet("/todos", (ApplicationDbContext dbContext) =>
+{
+    var todos = dbContext.Todos.ToList();
+    return todos;
+});
+
 app.MapDefaultEndpoints();
 
 if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Test"))

--- a/content/post/aspiretunit/AspireSample/AspireSample.AppHost.Tests/UnitTest1.cs
+++ b/content/post/aspiretunit/AspireSample/AspireSample.AppHost.Tests/UnitTest1.cs
@@ -20,4 +20,20 @@ public class UnitTest1 : DistributedApplicationBase
 
         await Assert.That(forecast).IsNotEmpty();
     }
+
+    [Test]
+    public async Task GetTodos()
+    {
+        var todo = new Todo { Name = "Test" };
+        var dbContext = GetRequiredService<ApplicationDbContext>();
+
+        dbContext.Todos.Add(todo);
+        dbContext.SaveChanges();
+
+        var httpClient = GetDistributedApplication().CreateHttpClient("apiservice");
+
+        var todos = await httpClient.GetFromJsonAsync<Todo[]>("todos");
+
+        await Assert.That(todos).IsNotEmpty();
+    }
 }


### PR DESCRIPTION
Hi @benjaminsampica , thank you for this example.

It made me realize that I can use both `DistributedApplicationTestingBuilder` and `WebApplicationFactory` in a single test project :)

In this PR, I added a sample API endpoint for getting todos, and added a corresponding test for it.